### PR TITLE
Update JNI target

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ for [Cloudflare Privacy Gateway Client Library](https://github.com/cloudflare/pr
 
 ```kotlin
 dependencies {
-    implementation("com.github.flohealth:ohttp-encapsulator:0.1.0")
+    implementation("com.github.flohealth:ohttp-encapsulator:0.2.0")
 }
 ```
 

--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -10,8 +10,8 @@ plugins {
 
 val javaVersion = JavaVersion.VERSION_1_8
 val buildType = "release"
-val libVersion = "0.1.0"
-val jniVersionTag = "v0.0.4"
+val libVersion = "0.2.0"
+val jniVersionTag = "v0.0.6"
 
 android {
     namespace = "health.flo.network.ohttp.encapsulator"


### PR DESCRIPTION
Why?

There is a new version of the CloudFlare library which has been compiled to support 16kb page alignment for Android 15+

What?

- Point to the new native library version
- Bump the library version